### PR TITLE
Plugin installer Plugin

### DIFF
--- a/milkman-auth/pom.xml
+++ b/milkman-auth/pom.xml
@@ -39,6 +39,16 @@
 						<descriptorRef>jar-with-dependencies</descriptorRef>
 					</descriptorRefs>
 					<appendAssemblyId>false</appendAssemblyId>
+					<archive>
+						<manifestSections>
+							<manifestSection>
+								<name>milkman.plugin</name>
+								<manifestEntries>
+									<Id>Milkman Auth Plugin</Id>
+								</manifestEntries>
+							</manifestSection>
+						</manifestSections>
+					</archive>
 				</configuration>
 				<executions>
 					<execution>

--- a/milkman-auth/pom.xml
+++ b/milkman-auth/pom.xml
@@ -45,6 +45,7 @@
 								<name>milkman.plugin</name>
 								<manifestEntries>
 									<Id>Milkman Auth Plugin</Id>
+									<Author>warmuuh</Author>
 								</manifestEntries>
 							</manifestSection>
 						</manifestSections>

--- a/milkman-cassandra/pom.xml
+++ b/milkman-cassandra/pom.xml
@@ -49,6 +49,7 @@
 								<name>milkman.plugin</name>
 								<manifestEntries>
 									<Id>Milkman Cassandra Plugin</Id>
+									<Author>warmuuh</Author>
 								</manifestEntries>
 							</manifestSection>
 						</manifestSections>

--- a/milkman-cassandra/pom.xml
+++ b/milkman-cassandra/pom.xml
@@ -1,30 +1,31 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  <parent>
-    <groupId>com.github.warmuuh</groupId>
-    <artifactId>milkman-parent</artifactId>
-    <version>5.8.0-SNAPSHOT</version>
-  </parent>
-  <artifactId>milkman-cassandra</artifactId>
-  
-  <dependencies>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>com.github.warmuuh</groupId>
+		<artifactId>milkman-parent</artifactId>
+		<version>5.8.0-SNAPSHOT</version>
+	</parent>
+	<artifactId>milkman-cassandra</artifactId>
+
+	<dependencies>
 		<dependency>
 			<groupId>com.github.warmuuh</groupId>
 			<artifactId>milkman</artifactId>
 			<version>5.8.0-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
-      <dependency>
-          <groupId>com.github.warmuuh</groupId>
-          <artifactId>milkman-jdbc</artifactId>
-          <version>5.8.0-SNAPSHOT</version>
-		  <scope>provided</scope>
-      </dependency>
-	  <dependency>
-		  <groupId>com.datastax.oss</groupId>
-		  <artifactId>java-driver-core</artifactId>
-		  <version>4.6.1</version>
-	  </dependency>
+		<dependency>
+			<groupId>com.github.warmuuh</groupId>
+			<artifactId>milkman-jdbc</artifactId>
+			<version>5.8.0-SNAPSHOT</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.datastax.oss</groupId>
+			<artifactId>java-driver-core</artifactId>
+			<version>4.6.1</version>
+		</dependency>
 		<dependency>
 			<groupId>io.netty</groupId>
 			<artifactId>netty-handler-proxy</artifactId>
@@ -42,6 +43,16 @@
 						<descriptorRef>jar-with-dependencies</descriptorRef>
 					</descriptorRefs>
 					<appendAssemblyId>false</appendAssemblyId>
+					<archive>
+						<manifestSections>
+							<manifestSection>
+								<name>milkman.plugin</name>
+								<manifestEntries>
+									<Id>Milkman Cassandra Plugin</Id>
+								</manifestEntries>
+							</manifestSection>
+						</manifestSections>
+					</archive>
 				</configuration>
 				<executions>
 					<execution>
@@ -55,5 +66,5 @@
 			</plugin>
 		</plugins>
 	</build>
-	
+
 </project>

--- a/milkman-dist/pom.xml
+++ b/milkman-dist/pom.xml
@@ -65,7 +65,6 @@
 			<artifactId>hsqldb</artifactId>
 			<version>2.4.1</version>
 		</dependency>
-
 		<dependency>
 			<groupId>com.github.warmuuh</groupId>
 			<artifactId>milkman-scripting</artifactId>
@@ -109,6 +108,11 @@
 		<dependency>
 			<groupId>com.github.warmuuh</groupId>
 			<artifactId>milkman-nosql</artifactId>
+			<version>5.8.0-SNAPSHOT</version>
+		</dependency>
+		<dependency>
+			<groupId>com.github.warmuuh</groupId>
+			<artifactId>milkman-plugins-management</artifactId>
 			<version>5.8.0-SNAPSHOT</version>
 		</dependency>
 

--- a/milkman-explore/pom.xml
+++ b/milkman-explore/pom.xml
@@ -47,6 +47,7 @@
 								<name>milkman.plugin</name>
 								<manifestEntries>
 									<Id>Milkman Explore Plugin</Id>
+									<Author>warmuuh</Author>
 								</manifestEntries>
 							</manifestSection>
 						</manifestSections>

--- a/milkman-explore/pom.xml
+++ b/milkman-explore/pom.xml
@@ -41,6 +41,16 @@
 						<descriptorRef>jar-with-dependencies</descriptorRef>
 					</descriptorRefs>
 					<appendAssemblyId>false</appendAssemblyId>
+					<archive>
+						<manifestSections>
+							<manifestSection>
+								<name>milkman.plugin</name>
+								<manifestEntries>
+									<Id>Milkman Explore Plugin</Id>
+								</manifestEntries>
+							</manifestSection>
+						</manifestSections>
+					</archive>
 				</configuration>
 				<executions>
 					<execution>

--- a/milkman-graphql/pom.xml
+++ b/milkman-graphql/pom.xml
@@ -34,6 +34,16 @@
 						<descriptorRef>jar-with-dependencies</descriptorRef>
 					</descriptorRefs>
 					<appendAssemblyId>false</appendAssemblyId>
+					<archive>
+						<manifestSections>
+							<manifestSection>
+								<name>milkman.plugin</name>
+								<manifestEntries>
+									<Id>Milkman GraphQL Plugin</Id>
+								</manifestEntries>
+							</manifestSection>
+						</manifestSections>
+					</archive>
 				</configuration>
 				<executions>
 					<execution>

--- a/milkman-graphql/pom.xml
+++ b/milkman-graphql/pom.xml
@@ -40,6 +40,7 @@
 								<name>milkman.plugin</name>
 								<manifestEntries>
 									<Id>Milkman GraphQL Plugin</Id>
+									<Author>warmuuh</Author>
 								</manifestEntries>
 							</manifestSection>
 						</manifestSections>

--- a/milkman-grpc/pom.xml
+++ b/milkman-grpc/pom.xml
@@ -68,6 +68,16 @@
 						<descriptorRef>jar-with-dependencies</descriptorRef>
 					</descriptorRefs>
 					<appendAssemblyId>false</appendAssemblyId>
+					<archive>
+						<manifestSections>
+							<manifestSection>
+								<name>milkman.plugin</name>
+								<manifestEntries>
+									<Id>Milkman GRPC Plugin</Id>
+								</manifestEntries>
+							</manifestSection>
+						</manifestSections>
+					</archive>
 				</configuration>
 				<executions>
 					<execution>

--- a/milkman-grpc/pom.xml
+++ b/milkman-grpc/pom.xml
@@ -74,6 +74,7 @@
 								<name>milkman.plugin</name>
 								<manifestEntries>
 									<Id>Milkman GRPC Plugin</Id>
+									<Author>warmuuh</Author>
 								</manifestEntries>
 							</manifestSection>
 						</manifestSections>

--- a/milkman-jdbc/pom.xml
+++ b/milkman-jdbc/pom.xml
@@ -26,6 +26,16 @@
 						<descriptorRef>jar-with-dependencies</descriptorRef>
 					</descriptorRefs>
 					<appendAssemblyId>false</appendAssemblyId>
+					<archive>
+						<manifestSections>
+							<manifestSection>
+								<name>milkman.plugin</name>
+								<manifestEntries>
+									<Id>Milkman JDBC Plugin</Id>
+								</manifestEntries>
+							</manifestSection>
+						</manifestSections>
+					</archive>
 				</configuration>
 				<executions>
 					<execution>

--- a/milkman-jdbc/pom.xml
+++ b/milkman-jdbc/pom.xml
@@ -32,6 +32,7 @@
 								<name>milkman.plugin</name>
 								<manifestEntries>
 									<Id>Milkman JDBC Plugin</Id>
+									<Author>warmuuh</Author>
 								</manifestEntries>
 							</manifestSection>
 						</manifestSections>

--- a/milkman-nosql/pom.xml
+++ b/milkman-nosql/pom.xml
@@ -61,6 +61,7 @@
 						<name>milkman.plugin</name>
 						<manifestEntries>
 							<Id>Milkman NoSQL Plugin</Id>
+                          <Author>warmuuh</Author>
 						</manifestEntries>
 					</manifestSection>
 				</manifestSections>

--- a/milkman-nosql/pom.xml
+++ b/milkman-nosql/pom.xml
@@ -55,6 +55,16 @@
             <descriptorRef>jar-with-dependencies</descriptorRef>
           </descriptorRefs>
           <appendAssemblyId>false</appendAssemblyId>
+			<archive>
+				<manifestSections>
+					<manifestSection>
+						<name>milkman.plugin</name>
+						<manifestEntries>
+							<Id>Milkman NoSQL Plugin</Id>
+						</manifestEntries>
+					</manifestSection>
+				</manifestSections>
+			</archive>
         </configuration>
         <executions>
           <execution>

--- a/milkman-note/pom.xml
+++ b/milkman-note/pom.xml
@@ -34,6 +34,7 @@
 								<name>milkman.plugin</name>
 								<manifestEntries>
 									<Id>Milkman Note Plugin</Id>
+									<Author>warmuuh</Author>
 								</manifestEntries>
 							</manifestSection>
 						</manifestSections>

--- a/milkman-note/pom.xml
+++ b/milkman-note/pom.xml
@@ -28,6 +28,16 @@
 						<descriptorRef>jar-with-dependencies</descriptorRef>
 					</descriptorRefs>
 					<appendAssemblyId>false</appendAssemblyId>
+					<archive>
+						<manifestSections>
+							<manifestSection>
+								<name>milkman.plugin</name>
+								<manifestEntries>
+									<Id>Milkman Note Plugin</Id>
+								</manifestEntries>
+							</manifestSection>
+						</manifestSections>
+					</archive>
 				</configuration>
 				<executions>
 					<execution>

--- a/milkman-plugins-management/README.md
+++ b/milkman-plugins-management/README.md
@@ -1,0 +1,16 @@
+# Milkman Plugin Management
+
+This plugin is meant to give the end-user the capability to easily install milkman plugins already downloaded to their local machine. Additionally, the user can
+easily remove existing plugins they don't want to use anymore.
+
+## Usage
+
+The plugin management can be reached via the Milkman's `Settings` dialog under the entry `Plugins`.
+
+### Installing Plugins
+
+Click the Add button and choose the plugin file in the open dialog. After installation, Milkman has to be restarted.
+
+### Uninstalling Plugins
+
+All currently installed plugins are shown in the table. Find the plugin you don't want to use anymore and click the `X` button. 

--- a/milkman-plugins-management/pom.xml
+++ b/milkman-plugins-management/pom.xml
@@ -35,6 +35,7 @@
 								<name>milkman.plugin</name>
 								<manifestEntries>
 									<Id>Milkman Plugins Management Plugin</Id>
+									<Author>Lars Opitz</Author>
 								</manifestEntries>
 							</manifestSection>
 						</manifestSections>

--- a/milkman-plugins-management/pom.xml
+++ b/milkman-plugins-management/pom.xml
@@ -1,13 +1,14 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>com.github.warmuuh</groupId>
 		<artifactId>milkman-parent</artifactId>
 		<version>5.8.0-SNAPSHOT</version>
 	</parent>
-	<artifactId>milkman-sio</artifactId>
+
+	<artifactId>milkman-plugins-management</artifactId>
+	<name>Milkman Plugins Management</name>
 
 	<dependencies>
 		<dependency>
@@ -15,27 +16,6 @@
 			<artifactId>milkman</artifactId>
 			<version>5.8.0-SNAPSHOT</version>
 			<scope>provided</scope>
-		</dependency>
-		<dependency>
-			<groupId>com.github.warmuuh</groupId>
-			<artifactId>milkman-rest</artifactId>
-			<version>5.8.0-SNAPSHOT</version>
-			<scope>provided</scope>
-		</dependency>
-		<dependency>
-			<groupId>com.github.warmuuh.milkman-sio-shaded-clients</groupId>
-			<artifactId>sio-client-v09</artifactId>
-			<version>1.2</version>
-		</dependency>
-		<dependency>
-			<groupId>com.github.warmuuh.milkman-sio-shaded-clients</groupId>
-			<artifactId>sio-client-v1</artifactId>
-			<version>1.2</version>
-		</dependency>
-		<dependency>
-			<groupId>com.github.warmuuh.milkman-sio-shaded-clients</groupId>
-			<artifactId>sio-client-v2</artifactId>
-			<version>1.2</version>
 		</dependency>
 	</dependencies>
 
@@ -54,7 +34,7 @@
 							<manifestSection>
 								<name>milkman.plugin</name>
 								<manifestEntries>
-									<Id>Milkman Socket.IO Plugin</Id>
+									<Id>Milkman Plugins Management Plugin</Id>
 								</manifestEntries>
 							</manifestSection>
 						</manifestSections>

--- a/milkman-plugins-management/src/main/java/milkman/ui/plugins/management/options/ListParser.java
+++ b/milkman-plugins-management/src/main/java/milkman/ui/plugins/management/options/ListParser.java
@@ -1,0 +1,27 @@
+package milkman.ui.plugins.management.options;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import lombok.experimental.UtilityClass;
+
+import static java.util.function.Predicate.not;
+
+@UtilityClass
+public class ListParser {
+
+	public static List<String> parseList(String source) {
+		return parseList(source, ",");
+	}
+
+	public static List<String> parseList(String source, String delimiter) {
+		return Optional
+			.ofNullable(source)
+			.stream()
+			.flatMap(s -> Arrays.stream(s.split(delimiter, 0)))
+			.map(String::trim)
+			.filter(not(String::isBlank))
+			.toList();
+	}
+}

--- a/milkman-plugins-management/src/main/java/milkman/ui/plugins/management/options/MilkmanInstallationLocationExtractor.java
+++ b/milkman-plugins-management/src/main/java/milkman/ui/plugins/management/options/MilkmanInstallationLocationExtractor.java
@@ -1,0 +1,53 @@
+package milkman.ui.plugins.management.options;
+
+import java.io.File;
+import java.util.Optional;
+
+import lombok.experimental.UtilityClass;
+import milkman.MilkmanApplication;
+import org.apache.commons.lang3.StringUtils;
+
+@UtilityClass
+public class MilkmanInstallationLocationExtractor {
+
+	private static final String OVERRIDE_PROPERTY_NAME = "milkman.installation.location";
+
+	public static String getMilkmanInstallationDirectory() {
+		return Optional
+			.ofNullable(System.getProperty(OVERRIDE_PROPERTY_NAME))
+			.orElseGet(MilkmanInstallationLocationExtractor::findMilkmanInstallationDirectory);
+	}
+
+	private static String findMilkmanInstallationDirectory() {
+		if (runningFromJar()) {
+			return getCurrentJarDirectory();
+		}
+		return getCurrentProjectDirectory();
+	}
+
+	private static boolean runningFromJar() {
+		return StringUtils.endsWithIgnoreCase(getJarName(), ".jar");
+	}
+
+	private static String getJarName() {
+		return getLocationForClass();
+	}
+
+	private static String getCurrentJarDirectory() {
+		return new File(getLocationForClass()).getParent();
+	}
+
+	private static String getLocationForClass() {
+		return new File(MilkmanApplication.class
+			.getProtectionDomain()
+			.getCodeSource()
+			.getLocation()
+			.getPath())
+			.getName();
+	}
+
+	private static String getCurrentProjectDirectory() {
+		return new File("").getAbsolutePath();
+	}
+
+}

--- a/milkman-plugins-management/src/main/java/milkman/ui/plugins/management/options/PluginManagementMessages.java
+++ b/milkman-plugins-management/src/main/java/milkman/ui/plugins/management/options/PluginManagementMessages.java
@@ -1,0 +1,38 @@
+package milkman.ui.plugins.management.options;
+
+import java.util.function.Function;
+
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+class PluginManagementMessages {
+	static final Function<String, String> ERROR_MESSAGE_PLUGIN_INSTALLATION_FAILED =
+		"""
+			The plugin was not successfully installed.
+						
+			Please check that your user has write permission in the Milkman installation directory
+			%s
+			and try again.
+			"""::formatted;
+
+	static final Function<PluginMetaData, String> SUCCESS_MESSAGE_PLUGIN_INSTALLATION = pluginMetaData ->
+		"""
+			The plugin
+						
+			%s
+			by %s
+						
+			was successfully installed.
+						
+			Please restart Milkman to enable the new plugin.
+			""".formatted(pluginMetaData.id(), String.join(", ", pluginMetaData.authors()));
+
+	static final Function<PluginMetaData, String> CONFIRMATION_MESSAGE_UNINSTALL_PLUGIN = pluginMetaData ->
+		"""
+			Do you really want to delete the plugin
+						
+			%s
+			by %s?
+			""".formatted(pluginMetaData.id(), String.join(", ", pluginMetaData.authors()));
+
+}

--- a/milkman-plugins-management/src/main/java/milkman/ui/plugins/management/options/PluginManager.java
+++ b/milkman-plugins-management/src/main/java/milkman/ui/plugins/management/options/PluginManager.java
@@ -1,0 +1,131 @@
+package milkman.ui.plugins.management.options;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.Comparator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+import java.util.jar.JarFile;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import javafx.scene.control.Alert;
+import javafx.scene.control.ButtonType;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+
+import static milkman.ExceptionDialog.showExceptionDialog;
+import static milkman.ui.plugins.management.options.PluginManagementMessages.ERROR_MESSAGE_PLUGIN_INSTALLATION_FAILED;
+import static milkman.ui.plugins.management.options.PluginManagementMessages.SUCCESS_MESSAGE_PLUGIN_INSTALLATION;
+
+@Slf4j
+public class PluginManager {
+
+	public Optional<PluginMetaData> installPlugin(File pluginFile) {
+		if (isValidPluginFile(pluginFile)) {
+			return copyPluginFile(pluginFile);
+		} else {
+			new Alert(Alert.AlertType.WARNING, "The selected file is not a valid Milkman Plugin file", ButtonType.CLOSE).showAndWait();
+		}
+		return Optional.empty();
+	}
+
+	private boolean isValidPluginFile(File result) {
+		return result.exists()
+			&& result.isFile()
+			&& result.canRead()
+			&& hasValidManifest(result);
+	}
+
+	private boolean hasValidManifest(File result) {
+		return extractPluginMetaData(result.toPath()).map(PluginMetaData::id).map(StringUtils::isNotBlank).orElse(false);
+	}
+
+	private Optional<PluginMetaData> copyPluginFile(File source) {
+		try {
+			var milkmanInstallationDirectory = MilkmanInstallationLocationExtractor.getMilkmanInstallationDirectory();
+			var copiedFile = copyPluginFileToTargetDirectory(source, Path.of(milkmanInstallationDirectory, "plugins", source.getName()));
+			var pluginMetaData = extractPluginMetaData(copiedFile);
+			pluginMetaData
+				.map(this::createSuccessInformation)
+				.orElseGet(() -> createErrorInformation(milkmanInstallationDirectory))
+				.showAndWait();
+			return pluginMetaData;
+		} catch (IOException e) {
+			log.warn("Error copying the plugin file", e);
+			showExceptionDialog("Warning", "Error copying the plugin", "There was an error copying the selected plugin file", e);
+		}
+		return Optional.empty();
+	}
+
+	private Path copyPluginFileToTargetDirectory(File source, Path target) throws IOException {
+		return Files.copy(source.toPath(), target, StandardCopyOption.REPLACE_EXISTING);
+	}
+
+	public List<PluginMetaData> getInstalledPlugins() {
+		try (var files = Files.list(Path.of(MilkmanInstallationLocationExtractor.getMilkmanInstallationDirectory(), "plugins"))) {
+			return filterPlugins(files);
+		} catch (Exception e) {
+			log.warn("Error fetch plugin files", e);
+			showExceptionDialog("Warning", "Reading installed plugins failed", "There was an error reading the installed plugins", e);
+		}
+		return new LinkedList<>();
+	}
+
+	private List<PluginMetaData> filterPlugins(Stream<Path> files) {
+		return files
+			.filter(p -> StringUtils.endsWithIgnoreCase(p.getFileName().toString(), ".jar"))
+			.map(this::extractPluginMetaData)
+			.flatMap(Optional::stream)
+			.sorted(Comparator.comparing(PluginMetaData::id))
+			.collect(Collectors.toCollection(LinkedList::new));
+	}
+
+	private Optional<PluginMetaData> extractPluginMetaData(Path path) {
+		try (var file = new JarFile(path.toFile())) {
+			return Optional
+				.ofNullable(file.getManifest())
+				.map(manifest -> manifest.getAttributes("milkman.plugin"))
+				.map(attributes -> new PluginMetaData(attributes.getValue("Id"), ListParser.parseList(attributes.getValue("Author")), path))
+				.filter(pluginMetaData -> StringUtils.isNotBlank(pluginMetaData.id()));
+		} catch (IOException e) {
+			log.warn("Error reading manifest of JAR file {}", path, e);
+		}
+		return Optional.empty();
+	}
+
+	public boolean uninstallPlugin(PluginMetaData plugin) {
+		try {
+			Files.delete(plugin.filename());
+			return true;
+		} catch (Exception e) {
+			log.warn("Unable to delete the plugin {} ({})", plugin.id(), plugin.filename());
+			showExceptionDialog(
+				"Error uninstalling the plugin",
+				"While uninstalling the plugin %s, an error has been encountered. Make sure your user has write permissions in the plugins directory of milkman (%s/plugins)".formatted(
+					plugin.id(),
+					MilkmanInstallationLocationExtractor.getMilkmanInstallationDirectory()),
+				e);
+		}
+		return false;
+	}
+
+	private Alert createSuccessInformation(PluginMetaData pluginMetaData) {
+		return new Alert(
+			Alert.AlertType.INFORMATION,
+			SUCCESS_MESSAGE_PLUGIN_INSTALLATION.apply(pluginMetaData),
+			ButtonType.CLOSE);
+	}
+
+	private Alert createErrorInformation(String milkmanInstallationDirectory) {
+		return new Alert(
+			Alert.AlertType.WARNING,
+			ERROR_MESSAGE_PLUGIN_INSTALLATION_FAILED.apply(milkmanInstallationDirectory),
+			ButtonType.CLOSE);
+	}
+
+}

--- a/milkman-plugins-management/src/main/java/milkman/ui/plugins/management/options/PluginMetaData.java
+++ b/milkman-plugins-management/src/main/java/milkman/ui/plugins/management/options/PluginMetaData.java
@@ -1,0 +1,7 @@
+package milkman.ui.plugins.management.options;
+
+import java.nio.file.Path;
+import java.util.List;
+
+public record PluginMetaData(String id, List<String> authors, Path filename) {
+}

--- a/milkman-plugins-management/src/main/java/milkman/ui/plugins/management/options/PluginsManagementOptions.java
+++ b/milkman-plugins-management/src/main/java/milkman/ui/plugins/management/options/PluginsManagementOptions.java
@@ -11,5 +11,5 @@ import milkman.ui.plugin.OptionsObject;
 @NoArgsConstructor
 @AllArgsConstructor
 public class PluginsManagementOptions implements OptionsObject {
-	private List<String> plugins;
+	private List<PluginMetaData> plugins;
 }

--- a/milkman-plugins-management/src/main/java/milkman/ui/plugins/management/options/PluginsManagementOptions.java
+++ b/milkman-plugins-management/src/main/java/milkman/ui/plugins/management/options/PluginsManagementOptions.java
@@ -1,0 +1,15 @@
+package milkman.ui.plugins.management.options;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import milkman.ui.plugin.OptionsObject;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class PluginsManagementOptions implements OptionsObject {
+	private List<String> plugins;
+}

--- a/milkman-plugins-management/src/main/java/milkman/ui/plugins/management/options/PluginsManagementOptionsProvider.java
+++ b/milkman-plugins-management/src/main/java/milkman/ui/plugins/management/options/PluginsManagementOptionsProvider.java
@@ -1,137 +1,85 @@
 package milkman.ui.plugins.management.options;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
+import java.util.Comparator;
+import java.util.LinkedList;
 import java.util.List;
-import java.util.Optional;
-import java.util.jar.JarFile;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.function.Function;
 
-import com.jfoenix.controls.JFXListView;
-import de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon;
-import javafx.geometry.Insets;
-import javafx.geometry.Pos;
 import javafx.scene.control.Alert;
+import javafx.scene.control.Alert.AlertType;
 import javafx.scene.control.ButtonType;
-import javafx.scene.control.ContentDisplay;
-import javafx.scene.layout.StackPane;
 import javafx.stage.FileChooser;
 import lombok.extern.slf4j.Slf4j;
-import milkman.ExceptionDialog;
 import milkman.ui.main.options.OptionDialogBuilder;
 import milkman.ui.main.options.OptionDialogPane;
 import milkman.ui.plugin.OptionPageProvider;
 import milkman.utils.fxml.FxmlUtil;
-import milkman.utils.fxml.GenericBinding;
-import org.apache.commons.lang3.StringUtils;
 
-import static milkman.utils.fxml.FxmlBuilder.button;
-import static milkman.utils.fxml.FxmlBuilder.icon;
-import static org.apache.commons.io.FilenameUtils.removeExtension;
+import static milkman.ui.plugins.management.options.PluginManagementMessages.CONFIRMATION_MESSAGE_UNINSTALL_PLUGIN;
 
 @Slf4j
 public class PluginsManagementOptionsProvider implements OptionPageProvider<PluginsManagementOptions> {
 
-	private PluginsManagementOptions options = new PluginsManagementOptions();
+	private final List<PluginMetaData> installedPlugins;
+	private final PluginManager pluginManager = new PluginManager();
+
+	public PluginsManagementOptionsProvider() {
+		this.installedPlugins = new LinkedList<>();
+	}
 
 	@Override
 	public PluginsManagementOptions getOptions() {
-		return options;
+		reloadInstalledPlugins();
+		return new PluginsManagementOptions(installedPlugins);
+	}
+
+	private void reloadInstalledPlugins() {
+		installedPlugins.clear();
+		installedPlugins.addAll(pluginManager.getInstalledPlugins());
 	}
 
 	@Override
 	public void setOptions(PluginsManagementOptions options) {
-		this.options = options;
+		//intentionally left empty, as the "options" of this plugin are not stored in the database but read in on showing the setting dialog
 	}
 
 	@Override
 	public OptionDialogPane getOptionsDialog(OptionDialogBuilder builder) {
-		var pane = new OptionDialogPane("Plugins", List.of(GenericBinding.of(this::getInstalledPlugins, null)));
-		pane.getStyleClass().add("options-page");
-		var list = new JFXListView<String>();
-		list.getItems().addAll(getInstalledPlugins(null));
-		pane.getChildren().add(list);
-		var addSection = new StackPane();
-		var button = button(icon(FontAwesomeIcon.PLUS, "1.5em"), this::installPlugin);
-		button.setContentDisplay(ContentDisplay.GRAPHIC_ONLY);
-		button.getStyleClass().add("btn-add-entry");
-		StackPane.setAlignment(button, Pos.BOTTOM_RIGHT);
-		StackPane.setMargin(button, new Insets(20, 20, 5, 0));
-
-		addSection.getChildren().add(button);
-		pane.getChildren().add(addSection);
-		return pane;
+		var columnValueProviders = new TreeMap<String, Function<PluginMetaData, String>>(Comparator.reverseOrder());
+		columnValueProviders.putAll(Map.of("Name", PluginMetaData::id, "Authors", data -> String.join(", ", data.authors())));
+		return builder
+			.page("Plugins", getOptions())
+			.section("Plugins")
+			.<PluginMetaData>list()
+			.itemProvider(PluginsManagementOptions::getPlugins)
+			.columnValueProviders(columnValueProviders)
+			.columnValueProviders(columnValueProviders)
+			.newValueProvider(this::installPlugin)
+			.vetoableListChangeListener(this::uninstallPlugin)
+			.endList()
+			.endSection()
+			.build();
 	}
 
-	private void installPlugin() {
+	private PluginMetaData installPlugin() {
 		var fileChooser = new FileChooser();
 		fileChooser.setTitle("Use Plugin");
 		fileChooser.getExtensionFilters().add(new FileChooser.ExtensionFilter("Plugin-Files (*.jar)", "*.jar"));
 		var result = fileChooser.showOpenDialog(FxmlUtil.getPrimaryStage());
 		if (result == null) {
-			return;
+			return null;
 		}
-		if (isValidPluginFile(result)) {
-			copyPluginFile(result);
-		} else {
-			new Alert(Alert.AlertType.WARNING, "The selected file is not a valid Milkman Plugin file", ButtonType.CLOSE).showAndWait();
-		}
+		return pluginManager.installPlugin(result).orElse(null);
 	}
 
-	private boolean isValidPluginFile(File result) {
-		return result.exists()
-			&& result.isFile()
-			&& result.canRead()
-			&& hasValidManifest(result);
-	}
-
-	private boolean hasValidManifest(File result) {
-		return StringUtils.isNotBlank(extractPluginNameFromManifest(result.toPath()));
-	}
-
-	private void copyPluginFile(File source) {
-		try {
-			var pluginName = extractPluginName(Files.copy(source.toPath(), Path.of(MilkmanInstallationLocationExtractor.getMilkmanInstallationDirectory(), "plugins", source.getName()), StandardCopyOption.REPLACE_EXISTING));
-			new Alert(Alert.AlertType.INFORMATION, "The plugin %s was successfully installed. Please restart Milkman to enable the new plugin.".formatted(pluginName), ButtonType.CLOSE).showAndWait();
-		} catch (IOException e) {
-			log.warn("Error copying the plugin file", e);
-			new ExceptionDialog("Warning", "Error copying the plugin", "There was an error copying the selected plugin file", e).showAndWait();
-		}
-	}
-
-	private List<String> getInstalledPlugins(PluginsManagementOptions pluginsManagementOptions) {
-		try {
-			return Files
-				.list(Path.of(MilkmanInstallationLocationExtractor.getMilkmanInstallationDirectory(), "plugins"))
-				.filter(p -> StringUtils.endsWithIgnoreCase(p.getFileName().toString(), ".jar"))
-				.map(this::extractPluginName)
-				.sorted()
-				.toList();
-		} catch (Exception e) {
-			log.warn("Error fetch plugin files", e);
-			new ExceptionDialog("Warning", "Reading installed plugins failed", "There was an error reading the installed plugins", e).showAndWait();
-		}
-		return List.of();
-	}
-
-	private String extractPluginName(Path path) {
-		var plainFileName = removeExtension(path.getFileName().toString());
-		return StringUtils.defaultIfBlank(extractPluginNameFromManifest(path), plainFileName);
-	}
-
-	private static String extractPluginNameFromManifest(Path path) {
-		try (var file = new JarFile(path.toFile())) {
-			return Optional
-				.ofNullable(file.getManifest())
-				.map(manifest -> manifest.getAttributes("milkman.plugin"))
-				.map(attributes -> attributes.getValue("Id"))
-				.filter(StringUtils::isNotBlank)
-				.orElse(null);
-		} catch (IOException e) {
-			log.warn("Error reading manifest of JAR file {}", path, e);
-		}
-		return null;
+	private boolean uninstallPlugin(PluginMetaData element) {
+		var alert = new Alert(AlertType.CONFIRMATION, CONFIRMATION_MESSAGE_UNINSTALL_PLUGIN.apply(element), ButtonType.YES, ButtonType.NO);
+		var result = alert.showAndWait();
+		return result
+			.filter(ButtonType.YES::equals)
+			.map(e -> pluginManager.uninstallPlugin(element))
+			.orElse(false);
 	}
 }

--- a/milkman-plugins-management/src/main/java/milkman/ui/plugins/management/options/PluginsManagementOptionsProvider.java
+++ b/milkman-plugins-management/src/main/java/milkman/ui/plugins/management/options/PluginsManagementOptionsProvider.java
@@ -1,0 +1,137 @@
+package milkman.ui.plugins.management.options;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.List;
+import java.util.Optional;
+import java.util.jar.JarFile;
+
+import com.jfoenix.controls.JFXListView;
+import de.jensd.fx.glyphs.fontawesome.FontAwesomeIcon;
+import javafx.geometry.Insets;
+import javafx.geometry.Pos;
+import javafx.scene.control.Alert;
+import javafx.scene.control.ButtonType;
+import javafx.scene.control.ContentDisplay;
+import javafx.scene.layout.StackPane;
+import javafx.stage.FileChooser;
+import lombok.extern.slf4j.Slf4j;
+import milkman.ExceptionDialog;
+import milkman.ui.main.options.OptionDialogBuilder;
+import milkman.ui.main.options.OptionDialogPane;
+import milkman.ui.plugin.OptionPageProvider;
+import milkman.utils.fxml.FxmlUtil;
+import milkman.utils.fxml.GenericBinding;
+import org.apache.commons.lang3.StringUtils;
+
+import static milkman.utils.fxml.FxmlBuilder.button;
+import static milkman.utils.fxml.FxmlBuilder.icon;
+import static org.apache.commons.io.FilenameUtils.removeExtension;
+
+@Slf4j
+public class PluginsManagementOptionsProvider implements OptionPageProvider<PluginsManagementOptions> {
+
+	private PluginsManagementOptions options = new PluginsManagementOptions();
+
+	@Override
+	public PluginsManagementOptions getOptions() {
+		return options;
+	}
+
+	@Override
+	public void setOptions(PluginsManagementOptions options) {
+		this.options = options;
+	}
+
+	@Override
+	public OptionDialogPane getOptionsDialog(OptionDialogBuilder builder) {
+		var pane = new OptionDialogPane("Plugins", List.of(GenericBinding.of(this::getInstalledPlugins, null)));
+		pane.getStyleClass().add("options-page");
+		var list = new JFXListView<String>();
+		list.getItems().addAll(getInstalledPlugins(null));
+		pane.getChildren().add(list);
+		var addSection = new StackPane();
+		var button = button(icon(FontAwesomeIcon.PLUS, "1.5em"), this::installPlugin);
+		button.setContentDisplay(ContentDisplay.GRAPHIC_ONLY);
+		button.getStyleClass().add("btn-add-entry");
+		StackPane.setAlignment(button, Pos.BOTTOM_RIGHT);
+		StackPane.setMargin(button, new Insets(20, 20, 5, 0));
+
+		addSection.getChildren().add(button);
+		pane.getChildren().add(addSection);
+		return pane;
+	}
+
+	private void installPlugin() {
+		var fileChooser = new FileChooser();
+		fileChooser.setTitle("Use Plugin");
+		fileChooser.getExtensionFilters().add(new FileChooser.ExtensionFilter("Plugin-Files (*.jar)", "*.jar"));
+		var result = fileChooser.showOpenDialog(FxmlUtil.getPrimaryStage());
+		if (result == null) {
+			return;
+		}
+		if (isValidPluginFile(result)) {
+			copyPluginFile(result);
+		} else {
+			new Alert(Alert.AlertType.WARNING, "The selected file is not a valid Milkman Plugin file", ButtonType.CLOSE).showAndWait();
+		}
+	}
+
+	private boolean isValidPluginFile(File result) {
+		return result.exists()
+			&& result.isFile()
+			&& result.canRead()
+			&& hasValidManifest(result);
+	}
+
+	private boolean hasValidManifest(File result) {
+		return StringUtils.isNotBlank(extractPluginNameFromManifest(result.toPath()));
+	}
+
+	private void copyPluginFile(File source) {
+		try {
+			var pluginName = extractPluginName(Files.copy(source.toPath(), Path.of(MilkmanInstallationLocationExtractor.getMilkmanInstallationDirectory(), "plugins", source.getName()), StandardCopyOption.REPLACE_EXISTING));
+			new Alert(Alert.AlertType.INFORMATION, "The plugin %s was successfully installed. Please restart Milkman to enable the new plugin.".formatted(pluginName), ButtonType.CLOSE).showAndWait();
+		} catch (IOException e) {
+			log.warn("Error copying the plugin file", e);
+			new ExceptionDialog("Warning", "Error copying the plugin", "There was an error copying the selected plugin file", e).showAndWait();
+		}
+	}
+
+	private List<String> getInstalledPlugins(PluginsManagementOptions pluginsManagementOptions) {
+		try {
+			return Files
+				.list(Path.of(MilkmanInstallationLocationExtractor.getMilkmanInstallationDirectory(), "plugins"))
+				.filter(p -> StringUtils.endsWithIgnoreCase(p.getFileName().toString(), ".jar"))
+				.map(this::extractPluginName)
+				.sorted()
+				.toList();
+		} catch (Exception e) {
+			log.warn("Error fetch plugin files", e);
+			new ExceptionDialog("Warning", "Reading installed plugins failed", "There was an error reading the installed plugins", e).showAndWait();
+		}
+		return List.of();
+	}
+
+	private String extractPluginName(Path path) {
+		var plainFileName = removeExtension(path.getFileName().toString());
+		return StringUtils.defaultIfBlank(extractPluginNameFromManifest(path), plainFileName);
+	}
+
+	private static String extractPluginNameFromManifest(Path path) {
+		try (var file = new JarFile(path.toFile())) {
+			return Optional
+				.ofNullable(file.getManifest())
+				.map(manifest -> manifest.getAttributes("milkman.plugin"))
+				.map(attributes -> attributes.getValue("Id"))
+				.filter(StringUtils::isNotBlank)
+				.orElse(null);
+		} catch (IOException e) {
+			log.warn("Error reading manifest of JAR file {}", path, e);
+		}
+		return null;
+	}
+}

--- a/milkman-plugins-management/src/main/resources/META-INF/services/milkman.ui.plugin.OptionPageProvider
+++ b/milkman-plugins-management/src/main/resources/META-INF/services/milkman.ui.plugin.OptionPageProvider
@@ -1,0 +1,1 @@
+milkman.ui.plugins.management.options.PluginsManagementOptionsProvider

--- a/milkman-plugins-management/src/test/java/milkman/ui/plugins/management/options/ListParserTest.java
+++ b/milkman-plugins-management/src/test/java/milkman/ui/plugins/management/options/ListParserTest.java
@@ -1,0 +1,45 @@
+package milkman.ui.plugins.management.options;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ListParserTest {
+
+	@ParameterizedTest
+	@MethodSource
+	@DisplayName("should parse lists correctly")
+	void shouldParseListsCorrectly(String source, List<String> expected, String delimiter) {
+		var result = ListParser.parseList(source, delimiter);
+
+		assertThat(result).containsExactlyElementsOf(expected);
+	}
+
+	@Test
+	@DisplayName("should parse list with default delimiter ,")
+	void shouldParseListWithDefaultDelimiter() {
+		var result = ListParser.parseList("a, b, c");
+
+		assertThat(result).containsExactly("a", "b", "c");
+	}
+
+	static Stream<Arguments> shouldParseListsCorrectly() {
+		return Stream
+			.of(
+				Arguments.of(null, List.of(), ","),
+				Arguments.of("", List.of(), ","),
+				Arguments.of(",", List.of(), ","),
+				Arguments.of("a,,c", List.of("a", "c"), ","),
+				Arguments.of("a, b, c,d,  e , f, ; and so much more", List.of("a", "b", "c", "d", "e", "f", "; and so much more"), ","),
+				Arguments.of("a; b; c;d;  e ; f; , and so much more", List.of("a", "b", "c", "d", "e", "f", ", and so much more"), ";")
+			);
+	}
+
+}

--- a/milkman-privatebin/pom.xml
+++ b/milkman-privatebin/pom.xml
@@ -37,6 +37,16 @@
 						<descriptorRef>jar-with-dependencies</descriptorRef>
 					</descriptorRefs>
 					<appendAssemblyId>false</appendAssemblyId>
+					<archive>
+						<manifestSections>
+							<manifestSection>
+								<name>milkman.plugin</name>
+								<manifestEntries>
+									<Id>Milkman Pastebin Plugin</Id>
+								</manifestEntries>
+							</manifestSection>
+						</manifestSections>
+					</archive>
 				</configuration>
 				<executions>
 					<execution>

--- a/milkman-privatebin/pom.xml
+++ b/milkman-privatebin/pom.xml
@@ -43,6 +43,7 @@
 								<name>milkman.plugin</name>
 								<manifestEntries>
 									<Id>Milkman Pastebin Plugin</Id>
+									<Author>warmuuh</Author>
 								</manifestEntries>
 							</manifestSection>
 						</manifestSections>

--- a/milkman-rest/pom.xml
+++ b/milkman-rest/pom.xml
@@ -158,6 +158,7 @@
 								<name>milkman.plugin</name>
 								<manifestEntries>
 									<Id>Milkman REST Plugin</Id>
+									<Author>warmuuh</Author>
 								</manifestEntries>
 							</manifestSection>
 						</manifestSections>

--- a/milkman-rest/pom.xml
+++ b/milkman-rest/pom.xml
@@ -152,6 +152,16 @@
 						<descriptorRef>jar-with-dependencies</descriptorRef>
 					</descriptorRefs>
 					<appendAssemblyId>false</appendAssemblyId>
+					<archive>
+						<manifestSections>
+							<manifestSection>
+								<name>milkman.plugin</name>
+								<manifestEntries>
+									<Id>Milkman REST Plugin</Id>
+								</manifestEntries>
+							</manifestSection>
+						</manifestSections>
+					</archive>
 				</configuration>
 				<executions>
 					<execution>

--- a/milkman-scripting/pom.xml
+++ b/milkman-scripting/pom.xml
@@ -76,6 +76,7 @@
 								<name>milkman.plugin</name>
 								<manifestEntries>
 									<Id>Milkman Scripting Plugin</Id>
+									<Author>warmuuh</Author>
 								</manifestEntries>
 							</manifestSection>
 						</manifestSections>

--- a/milkman-scripting/pom.xml
+++ b/milkman-scripting/pom.xml
@@ -70,6 +70,16 @@
 						<descriptorRef>jar-with-dependencies</descriptorRef>
 					</descriptorRefs>
 					<appendAssemblyId>false</appendAssemblyId>
+					<archive>
+						<manifestSections>
+							<manifestSection>
+								<name>milkman.plugin</name>
+								<manifestEntries>
+									<Id>Milkman Scripting Plugin</Id>
+								</manifestEntries>
+							</manifestSection>
+						</manifestSections>
+					</archive>
 				</configuration>
 				<executions>
 					<execution>

--- a/milkman-sio/pom.xml
+++ b/milkman-sio/pom.xml
@@ -55,6 +55,7 @@
 								<name>milkman.plugin</name>
 								<manifestEntries>
 									<Id>Milkman Socket.IO Plugin</Id>
+									<Author>warmuuh</Author>
 								</manifestEntries>
 							</manifestSection>
 						</manifestSections>

--- a/milkman-sync-git/pom.xml
+++ b/milkman-sync-git/pom.xml
@@ -62,6 +62,16 @@
 						<descriptorRef>jar-with-dependencies</descriptorRef>
 					</descriptorRefs>
 					<appendAssemblyId>false</appendAssemblyId>
+					<archive>
+						<manifestSections>
+							<manifestSection>
+								<name>milkman.plugin</name>
+								<manifestEntries>
+									<Id>Milkman Git Sync Plugin</Id>
+								</manifestEntries>
+							</manifestSection>
+						</manifestSections>
+					</archive>
 				</configuration>
 				<executions>
 					<execution>

--- a/milkman-sync-git/pom.xml
+++ b/milkman-sync-git/pom.xml
@@ -68,6 +68,7 @@
 								<name>milkman.plugin</name>
 								<manifestEntries>
 									<Id>Milkman Git Sync Plugin</Id>
+									<Author>warmuuh</Author>
 								</manifestEntries>
 							</manifestSection>
 						</manifestSections>

--- a/milkman-test/pom.xml
+++ b/milkman-test/pom.xml
@@ -28,6 +28,16 @@
 						<descriptorRef>jar-with-dependencies</descriptorRef>
 					</descriptorRefs>
 					<appendAssemblyId>false</appendAssemblyId>
+					<archive>
+						<manifestSections>
+							<manifestSection>
+								<name>milkman.plugin</name>
+								<manifestEntries>
+									<Id>Milkman Test Plugin</Id>
+								</manifestEntries>
+							</manifestSection>
+						</manifestSections>
+					</archive>
 				</configuration>
 				<executions>
 					<execution>

--- a/milkman-test/pom.xml
+++ b/milkman-test/pom.xml
@@ -34,6 +34,7 @@
 								<name>milkman.plugin</name>
 								<manifestEntries>
 									<Id>Milkman Test Plugin</Id>
+									<Author>warmuuh</Author>
 								</manifestEntries>
 							</manifestSection>
 						</manifestSections>

--- a/milkman-ws/pom.xml
+++ b/milkman-ws/pom.xml
@@ -39,6 +39,16 @@
 						<descriptorRef>jar-with-dependencies</descriptorRef>
 					</descriptorRefs>
 					<appendAssemblyId>false</appendAssemblyId>
+					<archive>
+						<manifestSections>
+							<manifestSection>
+								<name>milkman.plugin</name>
+								<manifestEntries>
+									<Id>Milkman WebSocket Plugin</Id>
+								</manifestEntries>
+							</manifestSection>
+						</manifestSections>
+					</archive>
 				</configuration>
 				<executions>
 					<execution>

--- a/milkman-ws/pom.xml
+++ b/milkman-ws/pom.xml
@@ -45,6 +45,7 @@
 								<name>milkman.plugin</name>
 								<manifestEntries>
 									<Id>Milkman WebSocket Plugin</Id>
+									<Author>warmuuh</Author>
 								</manifestEntries>
 							</manifestSection>
 						</manifestSections>

--- a/milkman/src/main/java/milkman/ExceptionDialog.java
+++ b/milkman/src/main/java/milkman/ExceptionDialog.java
@@ -56,5 +56,15 @@ public class ExceptionDialog extends Alert {
 		getDialogPane().setExpandableContent(expContent);
 	}
 
-	
+	public static void showExceptionDialog(String headerText, Throwable ex) {
+		new ExceptionDialog(headerText, ex.getClass().getName() + ": " + ex.getMessage(), ex).showAndWait();
+	}
+
+	public static void showExceptionDialog(String headerText, String contentText, Throwable ex) {
+		new ExceptionDialog(headerText, contentText, ex).showAndWait();
+	}
+
+	public static void showExceptionDialog(String title, String headerText, String contentText, Throwable ex) {
+		new ExceptionDialog(title, headerText, contentText, ex).showAndWait();
+	}
 }

--- a/milkman/src/main/java/milkman/ExceptionDialog.java
+++ b/milkman/src/main/java/milkman/ExceptionDialog.java
@@ -12,10 +12,22 @@ import javafx.scene.layout.Priority;
 public class ExceptionDialog extends Alert {
 
 	public ExceptionDialog(Throwable ex) {
+		this("Exception during startup of application", ex);
+	}
+
+	public ExceptionDialog(String headerText, Throwable ex) {
+		this(headerText, ex.getClass().getName() + ": " + ex.getMessage(), ex);
+	}
+
+	public ExceptionDialog(String headerText, String contentText, Throwable ex) {
+		this("Exception", headerText, contentText, ex);
+	}
+
+	public ExceptionDialog(String title, String headerText, String contentText, Throwable ex) {
 		super(AlertType.ERROR);
-		setTitle("Exception");
-		setHeaderText("Exception during startup of application");
-		setContentText(ex.getClass().getName() + ": " + ex.getMessage());
+		setTitle(title);
+		setHeaderText(headerText);
+		setContentText(contentText);
 
 
 		// Create expandable Exception.

--- a/milkman/src/main/java/milkman/ui/main/options/VetoableListItemRemovalListener.java
+++ b/milkman/src/main/java/milkman/ui/main/options/VetoableListItemRemovalListener.java
@@ -1,0 +1,6 @@
+package milkman.ui.main.options;
+
+@FunctionalInterface
+public interface VetoableListItemRemovalListener<T> {
+	boolean isElementRemovalAllowed(T element);
+}

--- a/pom.xml
+++ b/pom.xml
@@ -110,15 +110,10 @@
 			<dependency>
 				<groupId>com.fasterxml.jackson</groupId>
 				<artifactId>jackson-bom</artifactId>
-				<version>2.10.0</version>
+				<version>2.16.1</version>
 				<scope>import</scope>
 				<type>pom</type>
 			</dependency>
-			<!-- 			<dependency> -->
-			<!-- 				<groupId>com.fasterxml.jackson.core</groupId> -->
-			<!-- 				<artifactId>jackson-databind</artifactId> -->
-			<!-- 				<version>2.9.9.2</version> -->
-			<!-- 			</dependency> -->
 		</dependencies>
 	</dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.github.warmuuh</groupId>
 	<artifactId>milkman-parent</artifactId>
@@ -26,8 +26,9 @@
 		<module>milkman-auth</module>
 		<module>milkman-ws</module>
 		<module>milkman-sio</module>
-    <module>milkman-nosql</module>
-  </modules>
+		<module>milkman-nosql</module>
+		<module>milkman-plugins-management</module>
+	</modules>
 
 	<properties>
 		<maven.deploy.skip>true</maven.deploy.skip>
@@ -113,11 +114,11 @@
 				<scope>import</scope>
 				<type>pom</type>
 			</dependency>
-<!-- 			<dependency> -->
-<!-- 				<groupId>com.fasterxml.jackson.core</groupId> -->
-<!-- 				<artifactId>jackson-databind</artifactId> -->
-<!-- 				<version>2.9.9.2</version> -->
-<!-- 			</dependency> -->
+			<!-- 			<dependency> -->
+			<!-- 				<groupId>com.fasterxml.jackson.core</groupId> -->
+			<!-- 				<artifactId>jackson-databind</artifactId> -->
+			<!-- 				<version>2.9.9.2</version> -->
+			<!-- 			</dependency> -->
 		</dependencies>
 	</dependencyManagement>
 
@@ -142,10 +143,10 @@
 			<id>jitpack.io</id>
 			<url>https://jitpack.io</url>
 		</repository>
-<!--		<repository>-->
-<!--			<id>spring</id>-->
-<!--			<url>https://repo.spring.io/plugins-release</url>-->
-<!--		</repository>-->
+		<!--		<repository>-->
+		<!--			<id>spring</id>-->
+		<!--			<url>https://repo.spring.io/plugins-release</url>-->
+		<!--		</repository>-->
 	</repositories>
 
 	<build>


### PR DESCRIPTION
This adds a new Option Plug-in which allows to install downloaded plugins and uninstall plugins.
Currently, the plugin folder is determined using the milkman jar file location, but it can be overridden via `-Dmilkman.installation.location=`. This means, if the default plugin folder is changed (e.g. because of permission issues), the start script just needs to be adapted (or the system property needs to be set accordingly).

This PR also adds information to all existing plugins' Manifest.MF file containing name and author(s) of the plugin. 
This PR also updates the version of Jackson to 2.16.1 which allows serialization and deserialization of records.

The design is ok, but a little off as the option dialog is not very wide. The following screenshots show the plugin in action.

![image](https://github.com/warmuuh/milkman/assets/5472862/a2394f58-824b-415e-a280-51c29d613a69)

![image](https://github.com/warmuuh/milkman/assets/5472862/87d96a0e-7a0f-45e0-95ca-a3d57f7b109b)

![image](https://github.com/warmuuh/milkman/assets/5472862/6758d3a7-e6bf-46ab-860e-26bc031e147d)

![image](https://github.com/warmuuh/milkman/assets/5472862/19dfd591-b3c4-4405-a920-4f3cbff02d3e)

![image](https://github.com/warmuuh/milkman/assets/5472862/b7035bbc-994b-43b9-873d-cc11271eba83)

