### PR TITLE
feat(rest): add QUERY HTTP method support

### DIFF
--- a/milkman-rest/src/main/java/milkman/ui/plugin/rest/RestRequestEditController.java
+++ b/milkman-rest/src/main/java/milkman/ui/plugin/rest/RestRequestEditController.java
@@ -127,6 +127,7 @@ public class RestRequestEditController implements RequestTypeEditor, AutoComplet
 			methods.getItems().add("PATCH");
 			methods.getItems().add("HEAD");
 			methods.getItems().add("OPTIONS");
+			methods.getItems().add("QUERY");
 			
 			controller.requestUrl = add(new LongTextField(), true);
 			controller.requestUrl.setId("requestUrl");

--- a/milkman-rest/src/main/java/milkman/ui/plugin/rest/domain/RestRequestContainer.java
+++ b/milkman-rest/src/main/java/milkman/ui/plugin/rest/domain/RestRequestContainer.java
@@ -59,6 +59,8 @@ public class RestRequestContainer extends RequestContainer {
 				return style + "#257a35";
 			case "DELETE":
 				return style + "#eb3434";
+			case "QUERY":
+				return style + "#8b5cf6";
 			default:
 				return null;
 		}


### PR DESCRIPTION
## Summary

- Adds `QUERY` to the HTTP method dropdown in the REST request editor
- Adds a purple (`#8b5cf6`) sidebar badge color for QUERY requests
- No changes needed to either client processor (`JavaRequestProcessor` / `JettyRequestProcessor`): both already pass the method string through as-is, and the existing body-suppression logic only skips the body for GET and DELETE — QUERY correctly receives a body

## Test plan

- [ ] Build passes: `./mvnw -B package -DexcludedGroups=ui`
- [ ] Open the REST request editor — confirm `QUERY` appears in the method dropdown
- [ ] Create a QUERY request with a JSON body and fire it — confirm the method is sent as `QUERY` and the body is included
- [ ] Confirm saved QUERY requests show a purple badge in the sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)